### PR TITLE
Update workspace.bzl

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -565,7 +565,7 @@ def _tf_repositories():
 
     # Attention: TensorFlow Lite CMake build uses these variables, update only the URL and the checksum value.
     FFT2D_URL = "https://github.com/petewarden/OouraFFT/archive/v1.0.tar.gz"
-    FFT2D_SHA256 = "5f4dabc2ae21e1f537425d58a49cdca1c49ea11db0d6271e2a4b27e9697548eb"
+    FFT2D_SHA256 = "091a077903abce7804f6e3f961d81a10c65d6008ce1bba887058a392010c9027"
 
     tf_http_archive(
         name = "fft2d",

--- a/third_party/flatbuffers/workspace.bzl
+++ b/third_party/flatbuffers/workspace.bzl
@@ -5,7 +5,7 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 def repo():
     # Attention: TensorFlow Lite CMake build uses these variables, update only the URL and the checksum value.
     FLATBUFFERS_URL = "https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz"
-    FLATBUFFERS_SHA256 = "62f2223fb9181d1d6338451375628975775f7522185266cd5296571ac152bc45"
+    FLATBUFFERS_SHA256 = "01a2c46a064601795c549fb3012530de33697a4b00f1ee88e538af08f2f11009"
 
     tf_http_archive(
         name = "flatbuffers",


### PR DESCRIPTION
It seems that the sha256 of the flatbuffers 1.12.0 archive is different than what this configuration file specifies.