### PR TITLE
Update KleidiAI checksum.

### DIFF
--- a/tensorflow/workspace2.bzl
+++ b/tensorflow/workspace2.bzl
@@ -163,7 +163,7 @@ def _tf_repositories():
     # XNNPack dependency.
     tf_http_archive(
         name = "KleidiAI",
-        sha256 = "f3ea4fce53f3b31076958dbff229f0048dae15bf454929673c78292a56279d52",
+        sha256 = "3564707756473a165ddb3cf670187a4eeb2189c71c5ef01e865567cab071daac",
         strip_prefix = "kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a",
         urls = tf_mirror_urls("https://gitlab.arm.com/kleidi/kleidiai/-/archive/847ebd19d0192528659b0a0fa2c6057eed674c6a/kleidiai-847ebd19d0192528659b0a0fa2c6057eed674c6a.zip"),
     )


### PR DESCRIPTION
Due to KleidiAI change the checksum, it will cause NXP BSP compile error.